### PR TITLE
renaming from with_topshelf to run

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,3 +21,6 @@ PLATFORMS
 
 DEPENDENCIES
   albacore (~> 2.0)
+
+BUNDLED WITH
+   1.10.5

--- a/src/Topshelf.FSharp.Example/Program.fs
+++ b/src/Topshelf.FSharp.Example/Program.fs
@@ -36,4 +36,4 @@ let main argv =
   |> with_start start
   |> with_recovery (ServiceRecovery.Default |> restart (min 10))
   |> with_stop stop
-  |> with_topshelf
+  |> run

--- a/src/Topshelf.FSharp/FSharpApi.fs
+++ b/src/Topshelf.FSharp/FSharpApi.fs
@@ -14,7 +14,6 @@ module FSharpApi =
     { Start: HostControl -> bool
       Stop: HostControl -> bool
       HostConfiguration: (HostConfigurator -> HostConfigurator) list }
-
     static member Default = 
         { Start = (fun _ -> true)
           Stop = (fun _ -> true)
@@ -34,13 +33,16 @@ module FSharpApi =
   let create_service (hc:HostConfigurator) service_func = 
     hc.Service<ServiceControl>(service_func |> toFunc) |> ignore
 
-  let with_topshelf service = 
+  let run service = 
     let hostFactoryConfigurator hc = 
         let createdHc = service.HostConfiguration |> List.fold (fun chc x -> x chc) hc
         service_control service.Start service.Stop
         |> create_service createdHc
 
     hostFactoryConfigurator |> toAction1 |> HostFactory.Run |> int
+
+  [<Obsolete>]
+  let with_topshelf = run
 
   let with_start f service = 
     {service with Start = f}

--- a/src/Topshelf.FSharp/FSharpApi.fs
+++ b/src/Topshelf.FSharp/FSharpApi.fs
@@ -41,7 +41,7 @@ module FSharpApi =
 
     hostFactoryConfigurator |> toAction1 |> HostFactory.Run |> int
 
-  [<Obsolete>]
+  [<Obsolete("This function has been renamed, use run instead", false)>]
   let with_topshelf = run
 
   let with_start f service = 

--- a/src/Topshelf.FSharp/Topshelf.FSharp.fsproj
+++ b/src/Topshelf.FSharp/Topshelf.FSharp.fsproj
@@ -52,7 +52,7 @@
   <ItemGroup>
     <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="FSharpApi.fs" />
-    <None Include="packages.config" />
+    <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -62,7 +62,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Topshelf">
-      <HintPath>..\packages\Topshelf.3.1.3\lib\net40-full\Topshelf.dll</HintPath>
+      <HintPath>..\packages\Topshelf.3.2.0\lib\net40-full\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Topshelf.FSharp/packages.config
+++ b/src/Topshelf.FSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Topshelf" version="3.1.3" targetFramework="net40" />
+  <package id="Topshelf" version="3.2.0" targetFramework="net4" userInstalled="true" />
 </packages>


### PR DESCRIPTION
Two changes:
- Rename `with_topshelf` to `run`, since that is what the function do. The old one is stil there but marked `Obsolete`.
- Upgrade of topshelf to version 3.2, that is a minor upgrade so it shouldn't matter. I made it since I was working on a train and had cleaned out the old version but had this available.
